### PR TITLE
fix: 修改版本

### DIFF
--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -1,0 +1,10 @@
+name: multi-scf
+version: 0.3.10
+author: Tencent Cloud, Inc.
+org: Tencent Cloud, Inc.
+description: 多函数组件，允许用户开发部署多个腾讯 SCF 函数实例，适合进行多个函数开发的场景，如： 资源的增删改查功能。
+keywords: tencent, serverless, multi-scf
+repo: https://github.com/serverless-components/tencent-multi-scf
+readme: https://github.com/serverless-components/tencent-multi-scf/tree/master/README.md
+license: MIT
+main: ./build

--- a/src/package.json
+++ b/src/package.json
@@ -5,6 +5,6 @@
     "adm-zip": "^0.5.5",
     "fast-glob": "^3.2.5",
     "rimraf": "^3.0.2",
-    "tencent-component-toolkit": "^2.18.2"
+    "tencent-component-toolkit": "^2.23.2"
   }
 }

--- a/version.yml
+++ b/version.yml
@@ -1,1 +1,1 @@
-version: 0.3.9
+version: 0.3.10


### PR DESCRIPTION
总共两个bug
1. tencent-scf 这个component中涉及创建apigw触发器时 如果入参有autoType：APP 就是app鉴权方式的时候会调用apigw的bindApp接口，这个接口目前不支持可重入，第二次绑定会会报错
解决方式：查询Api绑定的应用列表 已经绑定直接跳过，未绑定执行绑定流程
2. 两次部署，yml中 tagKey一样，tagVaule变化了 部署时 调用的是attachTags绑定 接口，重复绑定会报错
解决方法是先解绑再绑定新的标签